### PR TITLE
extend register-new-crs 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -15,9 +15,9 @@
  :aliases {:check-deps {:extra-deps {olical/depot {:mvn/version "1.8.4"}}
                         :main-opts  ["-m" "depot.outdated.main"]}
            :make-jar   {:extra-deps {seancorfield/depstar {:mvn/version "1.0.97"}}
-                        :main-opts  ["-m" "hf.depstar.jar" "target/magellan-20200828.095539.jar"]}
+                        :main-opts  ["-m" "hf.depstar.jar" "target/magellan-20200902.112144.jar"]}
            :deploy     {:extra-deps {deps-deploy {:mvn/version "0.0.9"}}
-                        :main-opts  ["-m" "deps-deploy.deps-deploy" "deploy" "target/magellan-20200828.095539.jar"]}
+                        :main-opts  ["-m" "deps-deploy.deps-deploy" "deploy" "target/magellan-20200902.112144.jar"]}
            :test       {:extra-paths ["test"]
                         :extra-deps  {com.cognitect/test-runner
                                       {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>sig-gis</groupId>
   <artifactId>magellan</artifactId>
-  <version>20200828.095539</version>
+  <version>20200902.112144</version>
   <name>magellan</name>
   <description>
     Minimal API for Raster &amp; Vector Manipulation over GeoTools

--- a/src/magellan/core.clj
+++ b/src/magellan/core.clj
@@ -1,7 +1,9 @@
 (ns magellan.core
   (:require [schema.core :as s]
             [clojure.java.io :as io])
-  (:import (org.geotools.coverage.grid GridCoverage2D GridGeometry2D
+  (:import (java.net URL)
+           (java.awt.image RenderedImage)
+           (org.geotools.coverage.grid GridCoverage2D GridGeometry2D
                                        RenderedSampleDimension GridCoverageFactory)
            (org.geotools.coverage.grid.io GridFormatFinder AbstractGridFormat)
            (org.geotools.coverage GridSampleDimension)
@@ -15,8 +17,7 @@
            (org.geotools.coverage.processing Operations)
            (org.geotools.gce.geotiff GeoTiffWriter GeoTiffWriteParams)
            (org.opengis.referencing.crs CoordinateReferenceSystem)
-           (org.opengis.parameter GeneralParameterValue)
-           (java.awt.image RenderedImage)))
+           (org.opengis.parameter GeneralParameterValue)))
 
 (s/defrecord Raster
     [coverage   :- GridCoverage2D
@@ -76,15 +77,15 @@
 (s/defn register-new-crs-definitions-from-properties-file! :- s/Any
   [authority-name :- s/Str
    filename       :- s/Str]
-  (let [^java.net.URL file (if (instance? java.net.URL filename)
-                             filename
-                             (io/as-url (io/file filename)))]
+  (let [^URL url (if (instance? URL filename)
+                   filename
+                   (io/as-url (io/file filename)))]
     (ReferencingFactoryFinder/addAuthorityFactory
       (PropertyAuthorityFactory.
         (ReferencingFactoryContainer.
           (Hints. Hints/CRS_AUTHORITY_FACTORY PropertyAuthorityFactory))
         (Citations/fromName authority-name)
-        file)))
+        url)))
   (ReferencingFactoryFinder/scanForPlugins))
 
 (s/defn make-envelope :- Envelope2D

--- a/src/magellan/core.clj
+++ b/src/magellan/core.clj
@@ -76,12 +76,15 @@
 (s/defn register-new-crs-definitions-from-properties-file! :- s/Any
   [authority-name :- s/Str
    filename       :- s/Str]
-  (ReferencingFactoryFinder/addAuthorityFactory
-   (PropertyAuthorityFactory.
-    (ReferencingFactoryContainer.
-     (Hints. Hints/CRS_AUTHORITY_FACTORY PropertyAuthorityFactory))
-    (Citations/fromName authority-name)
-    (io/as-url (io/file filename))))
+  (let [^java.net.URL file (if (instance? java.net.URL filename)
+                             filename
+                             (io/as-url (io/file filename)))]
+    (ReferencingFactoryFinder/addAuthorityFactory
+      (PropertyAuthorityFactory.
+        (ReferencingFactoryContainer.
+          (Hints. Hints/CRS_AUTHORITY_FACTORY PropertyAuthorityFactory))
+        (Citations/fromName authority-name)
+        file)))
   (ReferencingFactoryFinder/scanForPlugins))
 
 (s/defn make-envelope :- Envelope2D

--- a/test/magellan/core_test.clj
+++ b/test/magellan/core_test.clj
@@ -4,7 +4,8 @@
             [magellan.core :as mg])
   (:import (org.geotools.geometry GeneralEnvelope Envelope2D)
            (org.geotools.referencing CRS)
-           (org.geotools.coverage.grid GridCoverage2D)))
+           (org.geotools.coverage.grid GridCoverage2D)
+           (magellan.core Raster)))
 
 ;;-----------------------------------------------------------------------------
 ;; Config
@@ -49,7 +50,7 @@
   (testing "Reading raster from file"
     (let [samp-raster (mg/read-raster (in-file-path "SRS-EPSG-3857.tif"))]
 
-      (is (instance? magellan.core.Raster samp-raster)))))
+      (is (instance? Raster samp-raster)))))
 
 (deftest write-raster-test
   (testing "Writing raster to file"
@@ -59,7 +60,7 @@
 
       (is (not (nil? my-rast)))
 
-      (is (instance? magellan.core.Raster my-rast))
+      (is (instance? Raster my-rast))
 
       (is (= (:crs samp-rast)
              (:crs my-rast)))
@@ -105,7 +106,7 @@
           rast           (mg/matrix-to-raster "some-name" matrix envelope)
           coverage       ^GridCoverage2D (:coverage rast)]
 
-      (is (instance? magellan.core.Raster rast))
+      (is (instance? Raster rast))
 
       (is (= (:crs rast) (.getCoordinateReferenceSystem coverage)))
 
@@ -129,7 +130,7 @@
           new-crs          (:crs (mg/read-raster (in-file-path "SRS-EPSG-32610.tif")))
           reprojected-rast (mg/reproject-raster samp-rast new-crs)]
 
-      (is (instance? magellan.core.Raster reprojected-rast))
+      (is (instance? Raster reprojected-rast))
 
       (is (not= (:crs samp-rast) new-crs)
           "New crs to be projected to should not be the same as the original")
@@ -165,7 +166,7 @@
           new-upper (map #(/ (+ %1 %2) 2) lower upper)
           new-rast  (mg/crop-raster samp-rast (GeneralEnvelope. lower (double-array new-upper)))]
 
-      (is (instance? magellan.core.Raster new-rast))
+      (is (instance? Raster new-rast))
 
       (is (not= (:envelope new-rast) (:envelope samp-rast))))))
 


### PR DESCRIPTION
In order to allow `register-crs-definitions-from-properties-file!` to work with
during tests and properly find resources when used in an application, we are 
extending this function to accept either a string or a `java.net.URL`.

----

#